### PR TITLE
Product Detail Refresh 500

### DIFF
--- a/components/rating/container.js
+++ b/components/rating/container.js
@@ -1,12 +1,11 @@
-import { RatingCard } from './card'
-import RatingForm from './form'
+import { RatingCard } from "./card";
+import RatingForm from "./form";
 
 export function RatingsContainer({ ratingCount, saveRating }) {
   return (
     <div className="tile is-parent is-12 is-vertical container">
       <RatingForm saveRating={saveRating} />
-      {/* Display the rating count instead of mapping through ratings */}
-      <p>{`This product has ${ratingCount} ratings.`}</p>
+      {/* RatingCard here ? */}
     </div>
-  )
+  );
 }

--- a/components/rating/detail.js
+++ b/components/rating/detail.js
@@ -1,20 +1,27 @@
-import { useState, useEffect } from 'react'
-import { rateProduct } from '../../data/products'
-import { RatingsContainer } from './container'
-import { Header } from './header'
-export function Ratings({ average_rating, refresh, ratingCount, number_purchased, number_of_likes }) {
-  const [productId, setProductId] = useState(0)
+import { useState, useEffect } from "react";
+import { rateProduct } from "../../data/products";
+import { RatingsContainer } from "./container";
+import { Header } from "./header";
+
+export function Ratings({
+  average_rating,
+  refresh,
+  ratingCount,
+  number_purchased,
+  number_of_likes,
+}) {
+  const [productId, setProductId] = useState(0);
   const saveRating = (newRating) => {
-    rateProduct(productId, newRating).then(refresh)
-  }
+    rateProduct(productId, newRating).then(refresh);
+  };
   useEffect(() => {
     if (ratingCount) {
-      setProductId(ratingCount.product)
+      setProductId(ratingCount.product);
     }
-  }, [ratingCount])
+  }, [ratingCount]);
   return (
     <div className="tile is-ancestor is-flex-wrap-wrap">
-      <Header 
+      <Header
         averageRating={average_rating}
         ratingsLen={ratingCount}
         numberPurchased={number_purchased}
@@ -22,5 +29,5 @@ export function Ratings({ average_rating, refresh, ratingCount, number_purchased
       />
       <RatingsContainer ratingCount={ratingCount} saveRating={saveRating} />
     </div>
-  )
+  );
 }

--- a/components/rating/form.js
+++ b/components/rating/form.js
@@ -1,19 +1,24 @@
-import { Rating } from 'react-simple-star-rating'
-import { useState } from 'react'
+import { useState } from "react";
+import dynamic from "next/dynamic";
 
 export default function RatingForm({ saveRating }) {
-  const [rating, setRating] = useState(0)
-  const [comment, setComment] = useState("")
-  
+  const [rating, setRating] = useState(0);
+  const [comment, setComment] = useState("");
+
+  const Rating = dynamic(
+    () => import("react-simple-star-rating").then((mod) => mod.Rating),
+    {
+      ssr: false,
+    }
+  );
+
   const submitRating = () => {
-    const outOf5 = rating/20
+    const outOf5 = rating / 20;
     saveRating({
       score: outOf5,
-      review: comment
-    })
-  }
-
-
+      review: comment,
+    });
+  };
 
   return (
     <div className="tile is-child ">
@@ -24,16 +29,23 @@ export default function RatingForm({ saveRating }) {
         <div className="media-content">
           <div className="field">
             <p className="control">
-              <textarea className="textarea" placeholder="Add your review" value={comment} onChange={(e) => setComment(e.target.value)}></textarea>
+              <textarea
+                className="textarea"
+                placeholder="Add your review"
+                value={comment}
+                onChange={(e) => setComment(e.target.value)}
+              ></textarea>
             </p>
           </div>
           <div className="field">
             <p className="control">
-              <button className="button" onClick={submitRating}>Post Rating</button>
+              <button className="button" onClick={submitRating}>
+                Post Rating
+              </button>
             </p>
           </div>
         </div>
       </article>
     </div>
-  )
+  );
 }


### PR DESCRIPTION
## Description
This PR completes the issue referenced in issue ticket [#48:](https://github.com/orgs/NSS-Day-Cohort-71/projects/22/views/1?pane=issue&itemId=81074197)

> When viewing a product detail page, and refreshing the page, a server error window displays:

> `ReferenceError: window is not defined`

> The console and API also display the following:

> `GET http://localhost:3000/products/50 500 (Internal Server Error)`

> The same error occurs when manually entering in the URL in the browser.

## Changes

- Item 1 - Removed `import { Rating } from 'react-simple-star-rating` from `/rating/form.js`
- Item 2 - Added `import dynamic from "next/dynamic` to `/rating/form.js`
- Item 3 - Added new `Rating` variable utilizing `dynamic`

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**


**Response**


## Testing

Description of how to test code...

- [x] Visit a Product Details page, and refresh the page.
- [x] If no error window displays, GOOD.
- [x] Manually set a new URL (ex. http://localhost:3000/products/5) and confirm that no error window displays.


## Related Issues

- Fixes #48