### PR TITLE
Changed 'seller' > 'customer' when retrieving store owner info

### DIFF
--- a/components/store/card.js
+++ b/components/store/card.js
@@ -11,7 +11,7 @@ export function StoreCard({ store, width= "is-half" }) {
         </header>
         <div className="card-content">
           <p className="content">
-            Owner: {store.seller.first_name} {store.seller.last_name}
+            Owner: {store.customer.first_name} {store.customer.last_name}
           </p>
           <div className="content">
             {store.description}


### PR DESCRIPTION
# Description

The store card was referencing a `seller` field name when fetching the Owner info. It should be `customer`.

Fixes # 46 (related)


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no errors

# How Should I Test This?

Please describe the steps required to verify your changes. Provide instructions so your teammate can reproduce.

- [x] Step 1 Refer to instructions in the API PR
