### PR TITLE
fixed the issue of the navbar eating the top of a page

### DIFF
--- a/global.css
+++ b/global.css
@@ -5,7 +5,10 @@ body {
     padding-top: 4.5rem;
 }
 
-.navbar.is-top {
-    z-index: 35;
-}
+.navbar.is-fixed-top {
+    position: fixed;
+    top: 0;
+    width: 100%;
+    z-index: 1000;
+  }
 

--- a/pages/products/[id]/index.js
+++ b/pages/products/[id]/index.js
@@ -53,7 +53,9 @@ ProductDetail.getLayout = function getLayout(page) {
   return (
     <Layout>
       <Navbar />
-      {page}
+      <section style={{ paddingTop: '6rem' }}>
+        {page}
+      </section>
     </Layout>
   )
 }

--- a/pages/products/index.js
+++ b/pages/products/index.js
@@ -58,7 +58,9 @@ Products.getLayout = function getLayout(page) {
   return (
     <Layout>
       <Navbar />
-      {page}
+      <section style={{ paddingTop: '4rem' }}> 
+        {page}
+      </section>
     </Layout>
   )
 }

--- a/pages/stores/index.js
+++ b/pages/stores/index.js
@@ -34,7 +34,9 @@ Stores.getLayout = function getLayout(page) {
   return (
     <Layout>
       <Navbar />
-      {page}
+      <section style={{ paddingTop: '4rem' }}>
+        {page}
+      </section>
     </Layout>
   )
 }


### PR DESCRIPTION
# Description

Fixed an issue where the top of certain pages were being consumed by the navbar. The fix was to add padding in the global css for the `navbar` component and some other padding on the affected pages where necessary.

Fixes # (issue)

#62

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no errors

# How Should I Test This?

Please describe the steps required to verify your changes. Provide instructions so your teammate can reproduce.

- [ ] Step 1 Fetch working branch and navigate to the products page
- [ ] Step 2 Click on any item to navigate to the corresponding details page
- [ ] Step 3 Navigate back and forth to different pages and observe to see if the issue is resolved
- [ ] Step 4 For some reason I needed to open the devtools network tab and then refresh for the changes to take hold, but this might just have been an issue for me
