### PR TITLE
Implemented SSR data fetch for the product form

### DIFF
--- a/components/product/form.js
+++ b/components/product/form.js
@@ -1,14 +1,8 @@
-import { useEffect, useState } from 'react'
-import { getCategories } from '../../data/products'
 import CardLayout from '../card-layout'
 import { Textarea, Select, Input } from '../form-elements'
 
-export default function ProductForm({ formEl, saveEvent, title, router }) {
-  const [categories, setCategories] = useState([])
 
-  useEffect(() => {
-    getCategories().then(catData => setCategories(catData))
-  }, [])
+export default function ProductForm({ categories, formEl, saveEvent, title, router }) {
 
   return (
     <CardLayout title={title}>

--- a/context/state.js
+++ b/context/state.js
@@ -17,6 +17,9 @@ export function AppWrapper({ children }) {
     const authRoutes = ['/login', '/register']
     if (token) {
       localStorage.setItem('token', token)
+
+      document.cookie = `token=${token}; path=/;`;
+
       if (!authRoutes.includes(router.pathname)) {
         getUserProfile().then((profileData) => {
           if (profileData) {

--- a/data/fetcher.js
+++ b/data/fetcher.js
@@ -8,7 +8,7 @@ const checkError = (res) => {
 }
 
 const checkErrorJson = (res) => {
-  if (!res.ok) { 
+  if (!res.ok) {
     throw Error(res.status);
   } else {
     return res.json();

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.15.4",
     "bulma": "^0.9.3",
+    "cookie": "^0.7.2",
     "next": "latest",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/pages/products/new.js
+++ b/pages/products/new.js
@@ -1,15 +1,34 @@
 import { useRouter } from 'next/router'
 import { useRef } from 'react'
+import cookie from 'cookie'
+
 import Layout from '../../components/layout'
 import Navbar from '../../components/navbar'
 import { addProduct } from '../../data/products'
 import ProductForm from '../../components/product/form'
-export default function NewProduct() {
+
+export async function getServerSideProps(context) {
+  const cookies = cookie.parse(context.req ? context.req.headers.cookie || '' : '');
+
+  // Retrieve the token from the cookies
+  const token = cookies.token;
+
+  const response = await fetch(`http://localhost:8000/productcategories`, {
+    headers: {
+      Authorization: `Token ${token}`
+    }
+  })
+
+  const categories = await response.json()
+  return { props: { categories } }
+}
+
+export default function NewProduct({ categories }) {
   const formEl = useRef()
   const router = useRouter()
 
   const saveProduct = () => {
-    const { name, description, price, category, location, quantity  } = formEl.current
+    const { name, description, price, category, location, quantity } = formEl.current
     const product = {
       name: name.value,
       description: description.value,
@@ -27,6 +46,7 @@ export default function NewProduct() {
       saveEvent={saveProduct}
       title="Add a new product"
       router={router}
+      categories={categories}
     ></ProductForm>
   )
 }


### PR DESCRIPTION
# Description

The fetch for categories now happens in the `new` page and is passed to the product form as a prop. Login component also changed so that a cookie named `token` is created on login so that the SSR can access it from the request object on the page context

Fixes # (issue)

n/a

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix
- [x] New feature

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no errors

# How Should I Test This

1. Logout of the app if you are currently authenticated
2. Log back in with any account
3. Verify that a new cookie is added by viewing the **Application** dev panel and expanding the cookies tree node for localhost:3000. There should be a cookie named **token** with the authorization token for the user.
4. Visit http://localhost:3000/products/new
5. Go to the **Network** dev panel _(make sure the filter is set to **All**)_
6. Click on the intial response _(should be labelled `new`)_
7. Verify that the entire form HTML - include all of the `<option>` tags for the select element are in the initial delivery of HTML from the Node server

