### PR TITLE
Feature/favorite store

### DIFF
--- a/components/store/detail.js
+++ b/components/store/detail.js
@@ -1,6 +1,8 @@
 import Link from 'next/link'
+import { useEffect } from 'react'
 
 export default function Detail({ store, isOwner, favorite, unfavorite }) {
+
   const ownerButtons = () => {
     return (
       <div className="buttons">
@@ -44,9 +46,6 @@ export default function Detail({ store, isOwner, favorite, unfavorite }) {
         <nav className="navbar">
           <div className="navbar-menu">
             <div className="navbar-end">
-              <span className="navbar-item">
-
-              </span>
             </div>
           </div>
         </nav>

--- a/components/store/detail.js
+++ b/components/store/detail.js
@@ -18,19 +18,21 @@ export default function Detail({ store, isOwner, favorite, unfavorite }) {
       <>
         {
           store.is_favorite ?
-            <button className="button is-primary is-inverted" onClick={unfavorite}>
+            (<button className="button is-primary is-inverted" onClick={unfavorite}>
               <span className="icon is-small">
                 <i className="fas fa-heart-broken"></i>
               </span>
               <span>Unfavorite Store</span>
-            </button>
+            </button>)
             :
+            (
             <button className="button is-primary is-inverted" onClick={favorite}>
               <span className="icon is-small">
                 <i className="fas fa-heart"></i>
               </span>
               <span>Favorite Store</span>
             </button>
+            )
         }
       </>
     )
@@ -43,12 +45,7 @@ export default function Detail({ store, isOwner, favorite, unfavorite }) {
           <div className="navbar-menu">
             <div className="navbar-end">
               <span className="navbar-item">
-                {
-                  isOwner ?
-                    ownerButtons()
-                    :
-                    userButtons()
-                }
+
               </span>
             </div>
           </div>
@@ -61,7 +58,15 @@ export default function Detail({ store, isOwner, favorite, unfavorite }) {
         <p className="subtitle">
           {store.description}
         </p>
+        <div>
+          {isOwner ?
+            ownerButtons()
+            :
+            userButtons()
+          }
+        </div>
       </div>
     </section>
   )
 }
+

--- a/data/stores.js
+++ b/data/stores.js
@@ -39,22 +39,23 @@ export function editStore(store) {
 }
 
 export function favoriteStore(storeId) {
-  return fetchWithoutResponse(`profile`, {
+  return fetchWithoutResponse(`profile/favoritesellers`, {
     method: 'POST',
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`,
       'Content-Type': 'application/json'
     },
-    body: JSON.stringify({"store_id": 3})
+    body: JSON.stringify({"store_id": storeId})
   })
 }
 
 export function unfavoriteStore(storeId) {
-  return fetchWithoutResponse(`stores/${storeId}/unfavorite`, {
+  return fetchWithoutResponse(`profile/favoritesellers`, {
     method: 'DELETE',
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`,
       'Content-Type': 'application/json'
     },
+    body: JSON.stringify({"store_id": storeId})
   })
 }

--- a/data/stores.js
+++ b/data/stores.js
@@ -39,12 +39,13 @@ export function editStore(store) {
 }
 
 export function favoriteStore(storeId) {
-  return fetchWithoutResponse(`stores/${storeId}/favorite`, {
+  return fetchWithoutResponse(`profile`, {
     method: 'POST',
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`,
       'Content-Type': 'application/json'
     },
+    body: JSON.stringify({"store_id": 3})
   })
 }
 

--- a/pages/stores/[id]/index.js
+++ b/pages/stores/[id]/index.js
@@ -21,6 +21,9 @@ export default function StoreDetail() {
   const [isOwner, setIsOwner] = useState(false);
 
   useEffect(() => {
+    if (parseInt(id) === profile.store?.id) {
+      setIsOwner(true)
+    }
     if (id) {
       refresh();
     }


### PR DESCRIPTION
# Description
- Updated favoriteStore() and unfavoriteStore() fetch requests url to go to '/profile' and send the "store_id" property to the API in the request body.
- Moved the owner vs user buttons turnary expression out of the navbar so it properly displays in the store header
- Now, when a user navigates to stores page and clicks on a store, if the store is the logged in user's store, Edit and Add Product buttons display; if the store is another user's store, button to either favorite or unfavorite displays, depending on whether the user has favorited the store already or not.


Fixes # (issue)
Ticket #17

## Type of change
- [ ] New feature

# Checklist:

- [x] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no errors

# How Should I Test This?

Please describe the steps required to verify your changes. Provide instructions so your teammate can reproduce.

- [ ] Log in as steve
- [ ] Go to the Stores View and click on the store "Steve's Stuff". Make sure the edit and add product buttons display.
- [ ] Go back to the Stores View, click on any of the other stores & make sure the "favorite" or "unfavorite" button displays
- [ ] Click to "favorite" and "unfavorite"
- [ ] Make sure at least one store is favorited, then navigate to the Profile view and make sure that store appears in the favorite stores section
- [ ] Make sure no errors pop up in the Console or Network tabs
