### PR TITLE
Updated StoreCard and layout of the Store View

### DIFF
--- a/components/store/card.js
+++ b/components/store/card.js
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 
-export function StoreCard({ store, width= "is-half" }) {
+export function StoreCard({ store, width= "is-full" }) {
   return (
     <div className={`column ${width}`}>
       <div className="card">
@@ -15,6 +15,9 @@ export function StoreCard({ store, width= "is-half" }) {
           </p>
           <div className="content">
             {store.description}
+          </div>
+          <div className="content">
+            {store.products.length} Items For Sale
           </div>
         </div>
         <footer className="card-footer">

--- a/pages/stores/index.js
+++ b/pages/stores/index.js
@@ -3,6 +3,7 @@ import Layout from '../../components/layout'
 import Navbar from '../../components/navbar'
 import { StoreCard } from '../../components/store/card'
 import { getStores } from '../../data/stores'
+import { ProductCard } from '../../components/product/card'
 
 
 export default function Stores() {
@@ -19,12 +20,23 @@ export default function Stores() {
   return (
     <>
       <h1 className="title">Stores</h1>
-      <div className="columns is-multiline">
-      {
+      <div className="store-list">
+       {
         stores.map(store => (
-          <StoreCard store={store} key={store.id} />
+          store.products.length > 0 && (
+            <div key={store.id} className="store-container">
+              <div className="store-card-wrapper">
+                <StoreCard store={store} />
+              </div>
+              <div className="columns is-multiline">
+                {store.products.map(product => (
+                    <ProductCard product={product} key={product.id}/>
+                ))}
+              </div>
+            </div>
+          )
         ))
-      }
+       } 
       </div>
     </>
   )


### PR DESCRIPTION
# Description
- StoreCard now displays the number of items for sale for a given store
- Store View displays the ProductCard for each item for sale below the StoreCard in the Stores View
- The Stores View only displays stores with products for sale

Fixes # (issue)
Issue Ticket #37

## Type of change

- [ ] New feature

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no errors

# How Should I Test This?

Please describe the steps required to verify your changes. Provide instructions so your teammate can reproduce.

- [ ] Navigate to the client browser
- [ ] Log in as any Admin user
- [ ] Go to the Stores View in the Navbar
- [ ] Make sure that the products card displays with the name of the store, the name of the store owner, the store description, and the number of items for sale for that store & the list of products for that store displays below the store card
- [ ] Create a new store with no products
- [ ] Verify that the newly created store or any store with zero products does not display in the Stores View
